### PR TITLE
Changed event to pull_request_target; added CONTRIBUTING.md; fixed error output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ Thumbs.db
 # Ignore built ts files
 __tests__/runner/*
 lib/**/*
+
+package-lock.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to github-pullrequest-to-work-item
+
+Thank you for contributing to github-pullrequest-to-work-item! Please see guidance below on how to make code changes, build and pack.
+
+## Requirements
+
+- [Git](https://git-scm.com/downloads)
+- [Node.js](https://nodejs.org/en/download/)
+- An IDE for editing Typescript code (e.g., [Visual Studio Code](https://code.visualstudio.com/download))
+
+## Making a change and submitting it
+
+- For this repo.
+- Clone your fork.
+- Create a new branch.
+- Make changes in TypeScript files (`*.ts`).
+- Compile it using `npm run build`.
+- Debug it, if necessary.
+- Generate the `index.js` file (pack it!) using `npm run pack`.
+- Commit & Push your branch to your fork.
+- Submit the PR.
+
+> NOTE: Don't forget to remove any credentials from the file if you added any for testing!

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ The id of the work item created or update
    Optional Env Variables
 
    - `github_token`: Used to update the Issue with AB# syntax to link the work item to the issue. This will only work if the project is configured to use the [GitHub Azure Boards](https://github.com/marketplace/azure-boards) app.
+   - `debug`: Used for more verbose log output.
 
 ```yaml
 name: Sync Pull Request to Azure Boards
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, closed]
     branches:
       - master
@@ -49,8 +50,7 @@ jobs:
         github_token: '${{ secrets.GH_TOKEN }}'    
         ado_organization: 'privatepreview'
         ado_project: 'Agile'
-        ado_wit: 'Pull Request' 
-        ado_new_state: 'New'
+        ado_wit: 'Pull Request'
         ado_active_state: 'Active'
         ado_close_state: 'Closed'
         ado_area_path: 'optional_area_path\\optional_area_path'

--- a/dist/index.js
+++ b/dist/index.js
@@ -6928,13 +6928,13 @@ const sample_webhookpayload_1 = __importDefault(__webpack_require__(78));
 const workitems_1 = __webpack_require__(445);
 const github_pr_1 = __webpack_require__(515);
 const patch = __importStar(__webpack_require__(286));
-const debug = false;
 const ado_org = '';
 const ado_project = '';
 const ado_token = '';
 const ado_wit = 'Pull Request';
 const ado_area_path = '';
 const github_token = '';
+let debug = false;
 // prettier-ignore
 function getEnvInputs() {
     const vm = new env_inputs_1.default();
@@ -6946,6 +6946,7 @@ function getEnvInputs() {
     vm.ado_active_state = process.env['ado_active_state'] !== undefined ? process.env['ado_active_state'] : 'Active';
     vm.github_token = process.env['github_token'] !== undefined ? process.env['github_token'] : github_token;
     vm.ado_area_path = process.env['ado_area_path'] !== undefined ? process.env['ado_area_path'] : ado_area_path;
+    debug = process.env['debug'] !== undefined ? process.env['debug'].toLowerCase() == 'true' : debug;
     return vm;
 }
 // prettier-ignore
@@ -9500,7 +9501,7 @@ exports.getUserAgent = getUserAgent;
 /* 215 */
 /***/ (function(module) {
 
-module.exports = {"_args":[["@octokit/rest@16.43.1","C:\\GitRepos\\Work\\github-actions-pr-to-work-item"]],"_from":"@octokit/rest@16.43.1","_id":"@octokit/rest@16.43.1","_inBundle":false,"_integrity":"sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==","_location":"/@octokit/rest","_phantomChildren":{"@octokit/types":"2.13.0","deprecation":"2.3.1","once":"1.4.0"},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.43.1","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.43.1","saveSpec":null,"fetchSpec":"16.43.1"},"_requiredBy":["/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz","_spec":"16.43.1","_where":"C:\\GitRepos\\Work\\github-actions-pr-to-work-item","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.1"};
+module.exports = {"name":"@octokit/rest","version":"16.43.1","publishConfig":{"access":"public"},"description":"GitHub REST API client for Node.js","keywords":["octokit","github","rest","api-client"],"author":"Gregor Martynus (https://github.com/gr2m)","contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"repository":"https://github.com/octokit/rest.js","dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"types":"index.d.ts","scripts":{"coverage":"nyc report --reporter=html && open coverage/index.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","pretest":"npm run -s lint","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","build":"npm-run-all build:*","build:ts":"npm run -s update-endpoints:typescript","prebuild:browser":"mkdirp dist/","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","prevalidate:ts":"npm run -s build:ts","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","start-fixtures-server":"octokit-fixtures-server"},"license":"MIT","files":["index.js","index.d.ts","lib","plugins"],"nyc":{"ignore":["test"]},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}]};
 
 /***/ }),
 /* 216 */,
@@ -33613,7 +33614,7 @@ function fetch(env, payload) {
             return response;
         }
         catch (ex) {
-            response.message.concat(JSON.stringify(ex));
+            response.message = response.message.concat(JSON.stringify(ex));
             response.workItem = null;
             response.success = false;
             return response;
@@ -33688,7 +33689,7 @@ function create(env, payload) {
             return response;
         }
         catch (ex) {
-            response.message.concat(JSON.stringify(ex));
+            response.message = response.message.concat(JSON.stringify(ex));
             response.workItem = null;
             response.success = false;
             return response;
@@ -33728,7 +33729,7 @@ function update(env, workItemId, patchDocument) {
             return response;
         }
         catch (ex) {
-            response.message.concat(JSON.stringify(ex));
+            response.message = response.message.concat(JSON.stringify(ex));
             response.workItem = null;
             response.success = false;
             return response;

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,89 +1,40 @@
 {
-  "_args": [
-    [
-      "azure-devops-node-api@10.1.1",
-      "C:\\GitRepos\\Work\\github-actions-pr-to-work-item"
-    ]
-  ],
-  "_from": "azure-devops-node-api@10.1.1",
-  "_id": "azure-devops-node-api@10.1.1",
-  "_inBundle": false,
-  "_integrity": "sha512-P4Hyrh/+Nzc2KXQk73z72/GsenSWIH5o8uiyELqykJYs9TWTVCxVwghoR7lPeiY6QVoXkq2S2KtvAgi5fyjl9w==",
-  "_location": "/azure-devops-node-api",
-  "_phantomChildren": {},
-  "_requested": {
-    "type": "version",
-    "registry": true,
-    "raw": "azure-devops-node-api@10.1.1",
     "name": "azure-devops-node-api",
-    "escapedName": "azure-devops-node-api",
-    "rawSpec": "10.1.1",
-    "saveSpec": null,
-    "fetchSpec": "10.1.1"
-  },
-  "_requiredBy": [
-    "/"
-  ],
-  "_resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.1.tgz",
-  "_spec": "10.1.1",
-  "_where": "C:\\GitRepos\\Work\\github-actions-pr-to-work-item",
-  "author": {
-    "name": "Microsoft Corporation"
-  },
-  "bugs": {
-    "url": "https://github.com/Microsoft/azure-devops-node-api/issues"
-  },
-  "contributors": [
-    {
-      "name": "Bryan MacFarlane",
-      "email": "bryanmac@microsoft.com"
+    "description": "Node client for Azure DevOps and TFS REST APIs",
+    "version": "10.1.1",
+    "main": "./WebApi.js",
+    "types": "./WebApi.d.ts",
+    "scripts": {
+        "build": "node make.js build",
+        "samples": "node make.js samples",
+        "test": "node make.js test",
+        "units": "node make.js units"
     },
-    {
-      "name": "Daniel McCormick",
-      "email": "daniel.mccormick@microsoft.com"
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/azure-devops-node-api"
     },
-    {
-      "name": "Scott Dallamura",
-      "email": "scdallam@microsoft.com"
+    "author": "Microsoft Corporation",
+    "contributors": [
+        "Bryan MacFarlane <bryanmac@microsoft.com>",
+        "Daniel McCormick<daniel.mccormick@microsoft.com>",
+        "Scott Dallamura <scdallam@microsoft.com>",
+        "Stephen Franceschelli<stephen.franceschelli@microsoft.com>",
+        "Teddy Ward <t-edward@microsoft.com>"
+    ],
+    "license": "MIT",
+    "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.7.3",
+        "underscore": "1.8.3"
     },
-    {
-      "name": "Stephen Franceschelli",
-      "email": "stephen.franceschelli@microsoft.com"
-    },
-    {
-      "name": "Teddy Ward",
-      "email": "t-edward@microsoft.com"
+    "devDependencies": {
+        "@types/mocha": "^2.2.44",
+        "@types/shelljs": "0.7.8",
+        "mocha": "^3.5.3",
+        "nock": "9.6.1",
+        "shelljs": "0.7.8",
+        "typescript": "3.1.5",
+        "@types/node": "8.9.2"
     }
-  ],
-  "dependencies": {
-    "tunnel": "0.0.6",
-    "typed-rest-client": "^1.7.3",
-    "underscore": "1.8.3"
-  },
-  "description": "Node client for Azure DevOps and TFS REST APIs",
-  "devDependencies": {
-    "@types/mocha": "^2.2.44",
-    "@types/node": "8.9.2",
-    "@types/shelljs": "0.7.8",
-    "mocha": "^3.5.3",
-    "nock": "9.6.1",
-    "shelljs": "0.7.8",
-    "typescript": "3.1.5"
-  },
-  "homepage": "https://github.com/Microsoft/azure-devops-node-api#readme",
-  "license": "MIT",
-  "main": "./WebApi.js",
-  "name": "azure-devops-node-api",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Microsoft/azure-devops-node-api.git"
-  },
-  "scripts": {
-    "build": "node make.js build",
-    "samples": "node make.js samples",
-    "test": "node make.js test",
-    "units": "node make.js units"
-  },
-  "types": "./WebApi.d.ts",
-  "version": "10.1.1"
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,6 @@ import {update as updatePr} from './github-pr'
 import {IResponse} from './interfaces/base-response'
 import * as patch from './patch-documents'
 
-const debug = false
 const ado_org = ''
 const ado_project = ''
 const ado_token = ''
@@ -19,6 +18,7 @@ const ado_wit = 'Pull Request'
 const ado_area_path = ''
 const github_token = ''
 
+let debug: boolean = false
 
 // prettier-ignore
 function getEnvInputs(): EnvInputs {
@@ -32,6 +32,7 @@ function getEnvInputs(): EnvInputs {
   vm.ado_active_state = process.env['ado_active_state'] !== undefined ? process.env['ado_active_state'] : 'Active'
   vm.github_token = process.env['github_token'] !== undefined ? process.env['github_token'] : github_token
   vm.ado_area_path = process.env['ado_area_path'] !== undefined ? process.env['ado_area_path'] : ado_area_path
+  debug = process.env['debug'] !== undefined ? process.env['debug'].toLowerCase() == 'true' : debug
 
   return vm
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,9 @@ import * as patch from './patch-documents'
 const ado_org = ''
 const ado_project = ''
 const ado_token = ''
-const ado_wit = 'Pull Request'
+const ado_wit = 'Task'
+const ad_active_state = 'Active'
+const ado_close_state = 'Closed'
 const ado_area_path = ''
 const github_token = ''
 
@@ -28,8 +30,8 @@ function getEnvInputs(): EnvInputs {
   vm.ado_organization = process.env['ado_organization'] !== undefined ? process.env['ado_organization'] : ado_org
   vm.ado_project = process.env['ado_project'] !== undefined ? process.env['ado_project'] : ado_project
   vm.ado_wit = process.env['ado_wit'] !== undefined ? process.env['ado_wit'] : ado_wit
-  vm.ado_close_state = process.env['ado_close_state'] !== undefined ? process.env['ado_close_state'] : 'Closed'
-  vm.ado_active_state = process.env['ado_active_state'] !== undefined ? process.env['ado_active_state'] : 'Active'
+  vm.ado_active_state = process.env['ado_active_state'] !== undefined ? process.env['ado_active_state'] : ad_active_state
+  vm.ado_close_state = process.env['ado_close_state'] !== undefined ? process.env['ado_close_state'] : ado_close_state
   vm.github_token = process.env['github_token'] !== undefined ? process.env['github_token'] : github_token
   vm.ado_area_path = process.env['ado_area_path'] !== undefined ? process.env['ado_area_path'] : ado_area_path
   debug = process.env['debug'] !== undefined ? process.env['debug'].toLowerCase() == 'true' : debug

--- a/src/workitems.ts
+++ b/src/workitems.ts
@@ -91,7 +91,7 @@ export async function fetch(
 
     return response
   } catch (ex) {
-    response.message.concat(JSON.stringify(ex))
+    response.message = response.message.concat(JSON.stringify(ex))
     response.workItem = null
     response.success = false
 
@@ -183,7 +183,7 @@ export async function create(
 
     return response
   } catch (ex) {
-    response.message.concat(JSON.stringify(ex))
+    response.message = response.message.concat(JSON.stringify(ex))
     response.workItem = null
     response.success = false
 
@@ -240,7 +240,7 @@ export async function update(
 
     return response
   } catch (ex) {
-    response.message.concat(JSON.stringify(ex))
+    response.message = response.message.concat(JSON.stringify(ex))
     response.workItem = null
     response.success = false
 


### PR DESCRIPTION
While I was debugging this action, I noticed some opportunities for improvements that you'll find in the changes:

- Switched event from `pull_request` to `pull_request_target` so this Action runs only from the base repo. This allows the Action to read the secrets. See details here: [Worksflows in forked repositories](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflows-in-forked-repositories)
- Fixed the error output when some routines failed. We were not concatenating the actual error to `response.message`
- Added `packages-lock.json` to `.gitignore`
- Added a CONTRIBUTING.md to guide first time contributors.