### PR TITLE
pr target, body is empty

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing to github-pullrequest-to-work-item
+
+Thank you for contributing to github-pullrequest-to-work-item! Please see guidance below on how to make code changes, build and pack.
+
+## Requirements
+
+- [Git](https://git-scm.com/downloads)
+- [Node.js](https://nodejs.org/en/download/)
+- An IDE for editing Typescript code (e.g., [Visual Studio Code](https://code.visualstudio.com/download))
+
+## Making a change and submitting it
+
+- For this repo.
+- Clone your fork.
+- Create a new branch.
+- Make changes in TypeScript files (`*.ts`).
+- If it's the first time you're building this project locally, run `npm install` before proceeding.
+- Compile it using `npm run build`.
+- Debug it, if necessary.
+- Generate the `index.js` file (pack it!) using `npm run pack`.
+- Commit & Push your branch to your fork.
+- Submit the PR.
+
+> NOTE: Don't forget to remove any credentials from the file if you added any for testing!

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The id of the work item created or update
 name: Sync Pull Request to Azure Boards
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, closed]
     branches:
       - master
@@ -50,9 +50,13 @@ jobs:
         github_token: '${{ secrets.GH_TOKEN }}'    
         ado_organization: 'privatepreview'
         ado_project: 'Agile'
-        ado_wit: 'Pull Request' 
+        ado_wit: 'User Story' 
         ado_new_state: 'New'
         ado_active_state: 'Active'
         ado_close_state: 'Closed'
         ado_area_path: 'optional_area_path\\optional_area_path'
 ```
+
+# Want to contribute?
+
+See [Contribution guidelines](CONTRIBUTING.md) for more information

--- a/dist/index.js
+++ b/dist/index.js
@@ -3067,7 +3067,7 @@ const sampleWebHookPayload = {
             type: 'User',
             site_admin: true
         },
-        body: null,
+        body: '',
         created_at: '2020-05-06T16:34:25Z',
         updated_at: '2020-05-06T16:34:25Z',
         closed_at: null,
@@ -12082,6 +12082,8 @@ const ado_org = '{organization}';
 const ado_project = '{project name}';
 const ado_token = '{azure devops personal access token}';
 const ado_wit = 'User Story';
+const ado_active_state = 'Active';
+const ado_close_state = 'Close';
 const github_token = '{github token}';
 const ado_area_path = '';
 // prettier-ignore
@@ -12091,8 +12093,8 @@ function getEnvInputs() {
     env.ado_organization = process.env['ado_organization'] !== undefined ? process.env['ado_organization'] : ado_org;
     env.ado_project = process.env['ado_project'] !== undefined ? process.env['ado_project'] : ado_project;
     env.ado_wit = process.env['ado_wit'] !== undefined ? process.env['ado_wit'] : ado_wit;
-    env.ado_close_state = process.env['ado_close_state'] !== undefined ? process.env['ado_close_state'] : 'Closed';
-    env.ado_active_state = process.env['ado_active_state'] !== undefined ? process.env['ado_active_state'] : 'Active';
+    env.ado_close_state = process.env['ado_close_state'] !== undefined ? process.env['ado_close_state'] : ado_close_state;
+    env.ado_active_state = process.env['ado_active_state'] !== undefined ? process.env['ado_active_state'] : ado_active_state;
     env.github_token = process.env['github_token'] !== undefined ? process.env['github_token'] : github_token;
     env.ado_area_path = process.env['ado_area_path'] !== undefined ? process.env['ado_area_path'] : ado_area_path;
     if (!verbose_logging)
@@ -12116,7 +12118,7 @@ function getEnvInputs() {
 }
 // prettier-ignore
 function getWebHookPayLoad() {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
+    var _a, _b, _c, _d, _e, _f, _g, _h;
     const body = (github_1.context !== undefined && !local_debug) ? github_1.context.payload : sample_webhookpayload_1.default;
     const payload = new payload_1.default();
     payload.action = body.action !== undefined ? body.action : '';
@@ -12129,7 +12131,7 @@ function getWebHookPayLoad() {
     payload.repo_fullname = ((_f = body.repository) === null || _f === void 0 ? void 0 : _f.full_name) !== undefined ? body.repository.full_name : '';
     payload.repo_owner = ((_g = body.repository) === null || _g === void 0 ? void 0 : _g.owner) !== undefined ? body.repository.owner.login : '';
     payload.sender_login = ((_h = body.sender) === null || _h === void 0 ? void 0 : _h.login) !== undefined ? body.sender.login : '';
-    payload.body = (((_j = body.pull_request) === null || _j === void 0 ? void 0 : _j.body) !== undefined || ((_k = body.pull_request) === null || _k === void 0 ? void 0 : _k.body) !== null) ? (_l = body.pull_request) === null || _l === void 0 ? void 0 : _l.body : '';
+    payload.body = body.pull_request != undefined && body.pull_request.body != undefined ? body.pull_request.body : '';
     return payload;
 }
 function run() {
@@ -38771,7 +38773,7 @@ function fetch(env, payload) {
             return response;
         }
         catch (ex) {
-            response.message.concat(JSON.stringify(ex));
+            response.message = response.message.concat(JSON.stringify(ex));
             response.workItem = null;
             response.success = false;
             return response;
@@ -38859,7 +38861,7 @@ function create(env, payload) {
             return response;
         }
         catch (ex) {
-            response.message.concat(JSON.stringify(ex));
+            response.message = response.message.concat(JSON.stringify(ex));
             response.workItem = null;
             response.success = false;
             return response;
@@ -38893,7 +38895,7 @@ function update(env, workItemId, patchDocument) {
             return response;
         }
         catch (ex) {
-            response.message.concat(JSON.stringify(ex));
+            response.message = response.message.concat(JSON.stringify(ex));
             response.workItem = null;
             response.success = false;
             return response;

--- a/src/debug/sample.webhookpayload.ts
+++ b/src/debug/sample.webhookpayload.ts
@@ -38,7 +38,7 @@ const sampleWebHookPayload: WebhookPayload = {
       type: 'User',
       site_admin: true
     },
-    body: null,
+    body: '',
     created_at: '2020-05-06T16:34:25Z',
     updated_at: '2020-05-06T16:34:25Z',
     closed_at: null,

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,8 @@ const ado_org = '{organization}'
 const ado_project = '{project name}'
 const ado_token = '{azure devops personal access token}'
 const ado_wit = 'User Story'
+const ado_active_state = 'Active'
+const ado_close_state = 'Close'
 const github_token = '{github token}'
 const ado_area_path = ''
 
@@ -28,8 +30,8 @@ function getEnvInputs(): EnvInputs {
   env.ado_organization = process.env['ado_organization'] !== undefined ? process.env['ado_organization'] : ado_org
   env.ado_project = process.env['ado_project'] !== undefined ? process.env['ado_project'] : ado_project
   env.ado_wit = process.env['ado_wit'] !== undefined ? process.env['ado_wit'] : ado_wit
-  env.ado_close_state = process.env['ado_close_state'] !== undefined ? process.env['ado_close_state'] : 'Closed'
-  env.ado_active_state = process.env['ado_active_state'] !== undefined ? process.env['ado_active_state'] : 'Active'
+  env.ado_close_state = process.env['ado_close_state'] !== undefined ? process.env['ado_close_state'] : ado_close_state
+  env.ado_active_state = process.env['ado_active_state'] !== undefined ? process.env['ado_active_state'] : ado_active_state
   env.github_token = process.env['github_token'] !== undefined ? process.env['github_token'] : github_token
   env.ado_area_path = process.env['ado_area_path'] !== undefined ? process.env['ado_area_path'] : ado_area_path  
   if (! verbose_logging) verbose_logging = process.env['debug'] !== undefined ? true : false
@@ -58,7 +60,7 @@ function getWebHookPayLoad(): Payload {
   payload.repo_fullname = body.repository?.full_name !== undefined ? body.repository.full_name : ''
   payload.repo_owner = body.repository?.owner !== undefined ? body.repository.owner.login : ''
   payload.sender_login = body.sender?.login !== undefined ? body.sender.login : ''  
-  payload.body = (body.pull_request?.body !== undefined || body.pull_request?.body !== null) ? body.pull_request?.body : ''  
+  payload.body = body.pull_request != undefined && body.pull_request.body != undefined ? body.pull_request.body : ''
 
   return payload
 }

--- a/src/workitems.ts
+++ b/src/workitems.ts
@@ -64,7 +64,7 @@ export async function fetch(env: EnvInputs, payload: Payload): Promise<IFetchRes
 
     return response
   } catch (ex) {
-    response.message.concat(JSON.stringify(ex))
+    response.message = response.message.concat(JSON.stringify(ex))
     response.workItem = null
     response.success = false
 
@@ -159,7 +159,7 @@ export async function create(env: EnvInputs, payload: Payload): Promise<IFetchRe
 
     return response
   } catch (ex) {
-    response.message.concat(JSON.stringify(ex))
+    response.message = response.message.concat(JSON.stringify(ex))
     response.workItem = null
     response.success = false
 
@@ -196,7 +196,7 @@ export async function update(env: EnvInputs, workItemId: number, patchDocument: 
 
     return response
   } catch (ex) {
-    response.message.concat(JSON.stringify(ex))
+    response.message = response.message.concat(JSON.stringify(ex))
     response.workItem = null
     response.success = false
 


### PR DESCRIPTION
Cherry picked from PR #29 

- Switched event from pull_request to pull_request_target so this Action runs only from the base repo. This allows the Action to read the secrets. See details here: [Worksflows in forked repositories](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflows-in-forked-repositories)
- Fixed the error output when some routines failed. We were not concatenating the actual error to response.message
- Added packages-lock.json to .gitignore
- Added a CONTRIBUTING.md to guide first time contributors.

Thank you @riserrad for your contributions